### PR TITLE
Make Fried Rice consistent.

### DIFF
--- a/examples/Fried Rice.cook
+++ b/examples/Fried Rice.cook
@@ -16,4 +16,4 @@ Add @prawns{150%g} and stir fry for 1 minute to heat through if pre-cooked, cook
 
 Add refrigerated overnight @cooked rice{3%cups}, Sauce, eggs, bacon and thinly sliced @scallions{5%items}. Stir fry for 2 minutes until rice is hot - around 2 minutes.
 
-Transfer to serving plate, sprinkle with thinly sliced @scallions{2%item} and serve.
+Transfer to serving plate, sprinkle with thinly sliced @scallions{2%items} and serve.


### PR DESCRIPTION
The names in the units are not consistent, though don't really comply with the specification. Otherwise this has to be externally specified and counts as undefined behavior.