### PR TITLE
New comments syntax

### DIFF
--- a/EBNF.md
+++ b/EBNF.md
@@ -49,6 +49,6 @@ new line character = ? newline characters (U+000A ~ U+000D, U+0085, U+2028, and 
 punctuation character = ? Unicode General Category P* ? ;
 symbol character = ? Unicode General Category S* ? ;
 
-(* comments will be changed to '--' soon, block comments to be added *)
-comments = "/", "/", ? any character ? ;
+comments = "-", "-", ? any character ?, new line character ;
+block comments = "[", "-", ? any character ?, "-", "]" ;
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Table of Contents
 * [Syntax Highlighting](#syntax-highlighting)
 
 ## About Cooklang
-Cooklang is the markup language at the center of an open-source ecosystem for cooking and recipe management. In Cooklang, each text file is a recipe written as plain-english instructions with markup syntax to add machine-parsible information about required ingredients, cookware, time, and metadata. Formal description of the language can be found [here](EBNF.md).
+Cooklang is the markup language at the center of an open-source ecosystem for cooking and recipe management. In Cooklang, each text file is a recipe written as plain-english instructions with markup syntax to add machine-parsible information about required ingredients, cookware, time, and metadata.
+
+More formal description of the language can be found [here](https://github.com/cooklang/spec/blob/main/EBNF.md).
 
 ## The .cook Recipe Specification
 Below is the specification for defining a recipe in cooklang. 
@@ -42,12 +44,16 @@ Place @bacon strips{1%kg} on a baking sheet and glaze with @syrup{1/2%tbsp}.
 ```
 
 ### Comments
-You can add comments to CookLang text with `//`.
+You can add comments up to the end of the line to CookLang text with `--`.
 ```
-// Don't burn the roux!
+-- Don't burn the roux!
 
-Mash @potato{2%kg} until smooth // alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.
-Slowly add @milk{4%cup}, keep mixing
+Mash @potato{2%kg} until smooth -- alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.
+```
+
+Or block comments with `[- comment text -]`.
+```
+Slowly add @milk{4%cup} [- TODO change units to litres -], keep mixing
 ```
 
 ### Metadata
@@ -153,8 +159,8 @@ If no ingredient scaling is defined, the same quantity will be used for all serv
 
 ```
 >> servings: 2|4|8
-Add @salt{1%tsp} // this is the same
-Add @salt{1|1|1%tsp} // as this
+Add @salt{1%tsp} -- this is the same
+Add @salt{1|1|1%tsp} -- as this
 ```
 
 ## Parser Implementation

--- a/examples/Coffee Souffle.cook
+++ b/examples/Coffee Souffle.cook
@@ -1,4 +1,4 @@
-// make caramel
+-- make caramel
 
 Crack the @egg yoke{1} into a bowl, then add the @condenced milk{125%g} and @instant coffee{3tsp}, and mix until a nice caramel is formed. Do not allow to bubble.
 

--- a/examples/Easy Pancakes.cook
+++ b/examples/Easy Pancakes.cook
@@ -1,4 +1,4 @@
-// TODO add source
+-- TODO add source
 
 Crack the @eggs{3} into a blender, then add the @flour{125%g}, @milk{250%ml} and @sea salt{1%pinch}, and blitz until smooth.
 

--- a/examples/Fried Rice.cook
+++ b/examples/Fried Rice.cook
@@ -1,4 +1,4 @@
-// TODO add source
+-- TODO add source
 
 Mix together @oyster sauce{1%tbsp}, @soy sauce{5%tbsp} and @sesame oil{5%tsp}, set aside.
 

--- a/examples/Olivier Salad.cook
+++ b/examples/Olivier Salad.cook
@@ -1,4 +1,4 @@
-// TODO add source
+-- TODO add source
 
 Zero step is cook @corn beef{1%kg}. Put into a large pan and simmer for ~{2%hours}.
 


### PR DESCRIPTION
Replaces old comment syntax `//` with `--`. Also adds support for block comments `[- comment text -]`.

Fixes: https://github.com/cooklang/CookInSwift/issues/7 and https://github.com/cooklang/spec/issues/21.