### PR TITLE
Add canonical tests + spelling fixes

### DIFF
--- a/tests/canonical.yaml
+++ b/tests/canonical.yaml
@@ -1,4 +1,4 @@
-version: 5
+version: 6
 tests:
   testBasicDirection:
     source: |
@@ -160,6 +160,7 @@ tests:
             value: " for some time"
       metadata: {}
 
+
   testEquipmentQuantity:
     source: |
       #frying pan{2}
@@ -170,6 +171,7 @@ tests:
             name: "frying pan"
             quantity: 2
       metadata: {}
+
 
   testEquipmentQuantityOneWord:
     source: |
@@ -182,6 +184,7 @@ tests:
             quantity: three
       metadata: {}
 
+
   testEquipmentQuantityMultipleWords:
     source: |
       #frying pan{two small}
@@ -192,6 +195,7 @@ tests:
             name: "frying pan"
             quantity: two small
       metadata: {}
+
 
   testFractions:
     source: |
@@ -566,7 +570,7 @@ tests:
             name: ""
       metadata: {}
 
-
+  
   testTimerWithName:
     source: |
       Fry for ~potato{42%minutes}
@@ -580,5 +584,245 @@ tests:
             units: "minutes"
             name: "potato"
       metadata: {}
+
+  
+  testSingleWordTimer:
+    source: |
+      Let it ~rest after plating
+    result:
+      steps:
+        -
+          - type: text
+            value: "Let it "
+          - type: timer
+            quantity: ""
+            units: ""
+            name: "rest"
+          - type: text
+            value: " after plating"
+      metadata: {}
+
+
+  testSingleWordTimerWithPunctuation:
+    source: |
+      Let it ~rest, then serve
+    result:
+      steps:
+        -
+          - type: text
+            value: "Let it "
+          - type: timer
+            quantity: ""
+            units: ""
+            name: "rest"
+          - type: text
+            value: ", then serve"
+      metadata: {}
+
+
+  testSingleWordTimerWithUnicodePunctuation:
+    source: |
+      Let it ~rest⸫ then serve
+    result:
+      steps:
+        -
+          - type: text
+            value: "Let it "
+          - type: timer
+            quantity: ""
+            units: ""
+            name: "rest"
+          - type: text
+            value: "⸫ then serve"
+      metadata: {}
+  
+  # NOTE: the space following `rest` is U+2009
+  testTimerWithUnicodeWhitespace:
+    source: |
+      Let it ~rest then serve
+    result:
+      steps:
+        -
+          - type: text
+            value: "Let it "
+          - type: timer
+            quantity: ""
+            units: ""
+            name: "rest"
+          - type: text
+            value: " then serve"
+      metadata: {}
+
+
+  testInvalidMultiWordTimer:
+    source: |
+      It is ~ {5}
+    result:
+      steps:
+        -
+          - type: text
+            value: "It is ~ {5}"
+      metadata: {}
+
+
+  testInvalidSingleWordTimer:
+    source: |
+      It is ~ 5
+    result:
+      steps:
+        -
+          - type: text
+            value: "It is ~ 5"
+      metadata: {}
+
+
+  testSingleWordIngredientWithPunctuation:
+    source: |
+      Add some @chilli, then serve
+    result:
+      steps:
+        -
+          - type: text
+            value: "Add some "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "chilli"
+          - type: text
+            value: ", then serve"
+      metadata: {}
+
+
+  testSingleWordIngredientWithUnicodePunctuation:
+    source: |
+      Add @chilli⸫ then bake
+    result:
+      steps:
+        -
+          - type: text
+            value: "Add "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "chilli"
+          - type: text
+            value: "⸫ then bake"
+      metadata: {}
+
+  
+  # NOTE: the space following `chilli` is U+2009
+  testIngredientWithUnicodeWhitespace:
+    source: |
+      Add @chilli then bake
+    result:
+      steps:
+        -
+          - type: text
+            value: "Add "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "chilli"
+          - type: text
+            value: " then bake"
+      metadata: {}
+
+
+  testInvalidMultiWordIngredient:
+    source: |
+      Message @ example{}
+    result:
+      steps:
+        -
+          - type: text
+            value: "Message @ example{}"
+      metadata: {}
+
+
+  testInvalidSingleWordIngredient:
+    source: |
+      Message me @ example
+    result:
+      steps:
+        -
+          - type: text
+            value: "Message me @ example"
+      metadata: {}
+
+
+  testSingleWordCookwareWithPunctuation:
+    source: |
+      Place in #pot, then boil
+    result:
+      steps:
+        -
+          - type: text
+            value: "Place in "
+          - type: cookware
+            quantity: 1
+            units: ""
+            name: "pot"
+          - type: text
+            value: ", then boil"
+      metadata: {}
+
+  testSingleWordCookwareWithUnicodePunctuation:
+    source: |
+      Place in #pot⸫ then boil
+    result:
+      steps:
+        -
+          - type: text
+            value: "Place in "
+          - type: cookware
+            quantity: 1
+            units: ""
+            name: "pot"
+          - type: text
+            value: "⸫ then boil"
+      metadata: {}
+
+  
+  # NOTE: the space following `pot` is U+2009
+  testCookwareWithUnicodeWhitespace:
+    source: |
+      Add to #pot then boil
+    result:
+      steps:
+        -
+          - type: text
+            value: "Add to "
+          - type: cookware
+            quantity: 1
+            units: ""
+            name: "pot"
+          - type: text
+            value: " then boil"
+      metadata: {}
+
+
+  testInvalidMultiWordCookware:
+    source: |
+      Recipe # 10{}
+    result:
+      steps:
+        -
+          - type: text
+            value: "Recipe # 10{}"
+      metadata: {}
+
+
+  testInvalidSingleWordCookware:
+    source: |
+      Recipe # 5
+    result:
+      steps:
+        -
+          - type: text
+            value: "Recipe # 5"
+      metadata: {}
+
+# NOTE: Unicode newlines may be impossible to test using YAML, 
+# given how the markup uses them for semantic reasoning.
 
 # TODO add common syntax errors

--- a/tests/canonical.yaml
+++ b/tests/canonical.yaml
@@ -21,7 +21,7 @@ tests:
 
   testCommentsAfterIngredients:
     source: |
-      @thyme{2%springs} -- testing comments
+      @thyme{2%sprigs} -- testing comments
       and some text
     result:
       steps:
@@ -29,7 +29,7 @@ tests:
           - type: ingredient
             name: "thyme"
             quantity: 2
-            units: "springs"
+            units: "sprigs"
           - type: text
             value: " "
         -
@@ -41,14 +41,14 @@ tests:
   testCommentsWithIngredients:
     source: |
       -- testing comments
-      @thyme{2%springs}
+      @thyme{2%sprigs}
     result:
       steps:
         -
           - type: ingredient
             name: "thyme"
             quantity: 2
-            units: "springs"
+            units: "sprigs"
       metadata: {}
 
 
@@ -74,7 +74,7 @@ tests:
       metadata: {}
 
 
-  testDirectionWithIngrident:
+  testDirectionWithIngredient:
     source: |
       Add @chilli{3%items}, @ginger{10%g} and @milk{1%l}.
     result:
@@ -225,7 +225,7 @@ tests:
         -
           - type: ingredient
             name: "milk"
-            quantity: 01/2
+            quantity: "01/2"
             units: "cup"
       metadata: {}
 
@@ -273,7 +273,7 @@ tests:
       metadata: {}
 
 
-  testIngridentExplicitUnits:
+  testIngredientExplicitUnits:
     source: |
       @chilli{3%items}
     result:
@@ -286,7 +286,7 @@ tests:
       metadata: {}
 
 
-  testIngridentExplicitUnitsWithSpaces:
+  testIngredientExplicitUnitsWithSpaces:
     source: |
       @chilli{ 3 % items }
     result:
@@ -299,7 +299,7 @@ tests:
       metadata: {}
 
 
-  testIngridentImplicitUnits:
+  testIngredientImplicitUnits:
     source: |
       @chilli{3}
     result:
@@ -312,7 +312,7 @@ tests:
       metadata: {}
 
 
-  testIngridentNoUnits:
+  testIngredientNoUnits:
     source: |
       @chilli
     result:
@@ -325,7 +325,7 @@ tests:
       metadata: {}
 
 
-  testIngridentNoUnitsNotOnlyString:
+  testIngredientNoUnitsNotOnlyString:
     source: |
       @5peppers
     result:
@@ -338,7 +338,7 @@ tests:
       metadata: {}
 
 
-  testIngridentWithNumbers:
+  testIngredientWithNumbers:
     source: |
       @tipo 00 flour{250%g}
     result:
@@ -351,7 +351,7 @@ tests:
       metadata: {}
 
 
-  testIngridentWithoutStopper:
+  testIngredientWithoutStopper:
     source: |
       @chilli cut into pieces
     result:
@@ -431,7 +431,7 @@ tests:
         "Cook Time": 30 minutes
 
 
-  testMultiWordIngrident:
+  testMultiWordIngredient:
     source: |
       @hot chilli{3}
     result:
@@ -444,7 +444,7 @@ tests:
       metadata: {}
 
 
-  testMultiWordIngridentNoAmount:
+  testMultiWordIngredientNoAmount:
     source: |
       @hot chilli{}
     result:
@@ -457,7 +457,7 @@ tests:
       metadata: {}
 
 
-  testMutipleIngridentsWithoutStopper:
+  testMutipleIngredientsWithoutStopper:
     source: |
       @chilli cut into pieces and @garlic
     result:
@@ -478,14 +478,14 @@ tests:
 
   testQuantityAsText:
     source: |
-      @thyme{few%springs}
+      @thyme{few%sprigs}
     result:
       steps:
         -
           - type: ingredient
             name: "thyme"
             quantity: few
-            units: "springs"
+            units: "sprigs"
       metadata: {}
 
 


### PR DESCRIPTION
Adds test coverage for single word timers, punctuation, unicode punctuation, unicode whitespace and invalid syntax for components (e.g. `Message @ example` is not a valid ingredient per the EBNF)

The invalid syntax tests may a bit extra and perhaps should be excluded, I'm not sure the stance on that.

Set the result quantity of `testFractionsLike: @milk{01/2%cup}` to be an explicit string rather than a number(?) as I believe that will cause inconsistencies with YAML parsers. It should either be `0.5` or `"01/2"`, depending which is the sought after behaviour.

Also fixed some minor typos

EDIT: I also tried to make each test have a uniform 2 space gap, as it was split between one and two, however I see I missed one and put a space on one of the newlines :P