### PR TITLE
0005 Notes

### DIFF
--- a/proposals/0005-note-blocks.md
+++ b/proposals/0005-note-blocks.md
@@ -6,64 +6,90 @@
 
 ## Introduction
 
-The proposal aims to add a new block type to the Cooklang language: note.
+This proposal outlines a plan to add a new block type to the Cooklang language: the note.
 
-This new block type will allow recipe authors to add arbitrary notes to the recipe,
-which will be displayed in the app as notes.
+This feature will allow recipe authors to embed standalone notes in their recipes,
+giving them a way to store relevant background, insights, or personal anecdotes
+that aren't part of the cooking steps. Notes won’t be displayed during cooking mode,
+but they will appear in the recipe details view, providing context without cluttering
+the active instructions.
 
-Why we need this?
-
-Discussion thread: ["Additional notes" section which isn't a step, but extra information about a recipe](https://github.com/cooklang/spec/discussions/81) and [Description, notes, and metadata...](https://github.com/cooklang/spec/discussions/46).
+Discussion thread: ["Additional notes" section which isn't a step, but extra information about a recipe](https://github.com/cooklang/spec/discussions/81)
+and [Description, notes, and metadata...](https://github.com/cooklang/spec/discussions/46).
 
 ## Motivation
 
-Describe the problems that this proposal seeks to address. If the
-problem is that some common pattern is currently hard to express, show
-how one can currently get a similar effect and describe its
-drawbacks. If it's completely new functionality that cannot be
-emulated, motivate why this new functionality would help Cooklang community
-use Cooklang better.
+Recipes are more than a sequence of steps; they’re stories, memories, and moments
+preserved. Imagine a recipe handed down through generations: a great-grandmother’s
+Siberian fish soup, spiced with the unique blend she carried across a journey.
+While the specifics of that story might be fictional, the desire to capture memories
+like it is very real.
+
+While these stories don’t change the outcome of a dish, they’re significant. Cooklang,
+however, currently lacks an effective way to preserve this kind of narrative
+information. Metadata or additional steps can somewhat work, but neither
+fits naturally, often cluttering the recipe. A dedicated syntax for
+notes will let recipe creators embed these details in a way that keeps
+them distinct from the active cooking process.
 
 ## Proposed solution
 
-Describe your solution to the problem. Provide examples and describe
-how they work. Show how your solution is better than current
-workarounds (if any).
+The solution is to introduce a new block type in Cooklang for notes, using
+a Markdown-inspired syntax for clarity and simplicity.
+
+To add a note, authors will simply use a > symbol at the beginning of a paragraph:
+
+```
+> This dish is even better the next day, after the flavors have melded overnight.
+```
+
+This approach keeps note-taking lightweight and integrates easily with the language,
+while visually signaling that the text is extra information. Notes will be displayed
+in the recipe details but hidden during cooking, making them easily accessible
+when needed without disrupting the cooking flow.
+
 
 ## Detailed design
 
-Describe the design of the solution in detail. If it involves new
-syntax in the language, show the additions and changes to the Cooklang
-grammar. If it's a new API, show the full API and its documentation
-comments detailing what it does. The detail in this section should be
-sufficient for someone who is *not* one of the authors to be able to
-reasonably implement the feature.
+The design introduces a straightforward syntax addition to the Cooklang grammar.
+In a recipe file, any line beginning with `>` will be recognized as a note and
+rendered as such in applications that support the new syntax.
+
+### EBNF update
+
+```
+recipe = { metadata | step | note }- ;
+
+note = ">", { text item }-, new line character ;
+```
 
 ## Effect on applications which use Cooklang
 
-Changes in Cooklang syntax often require supplementary UI changes in
-apps which use it (otherwise why these changes if nothing will
-use them). Describe in details what changes should be implemented.
-The detail in this section should be sufficient for someone
-who is *not* one of the authors to be able to reasonably implement
-the feature.
-
-### CookCLI (terminal and web-server)
-
-Does the proposal change the output of
-[CookCLI](https://github.com/cooklang/CookCLI)? Does it require adding
-a new sub-command to fully use this feature?
+The addition of note syntax will affect the output of CookCLI. No new sub-commands
+are needed; however, the recipe parser must recognize and render > blocks as notes,
+showing them in the recipe detail view but hiding them during the cooking view.
 
 ### Mobile applications
 
-Does the proposal require changes in mobile application UI? Describe
-what screens should be changed and how. Give as much details as
-possible.
+Mobile apps will need UI adjustments to display notes in the recipe details. Notes
+should be visually distinct, perhaps styled in italics or a slightly different color,
+ensuring they’re recognized as supplementary information.
 
 ## Alternatives considered
 
-Describe alternative approaches to addressing the same problem, and
-why you chose this approach instead.
+### Embedding Notes in Metadata
+
+Storing notes as metadata is a possible approach, but it lacks the intuitive,
+in-line placement that allows notes to appear naturally within the recipe flow. Metadata
+is typically reserved for more structured data like prep times or dietary information,
+so this could lead to cluttered, less-readable recipes.
+
+### Using Special Delimiters in Steps
+
+Another alternative would be to add an indicator within the steps themselves. However,
+since notes are not meant to appear in the cooking flow, this would be counterintuitive
+and likely disrupt the cooking experience. The block quote syntax keeps notes separate
+and accessible without interference.
 
 ## Acknowledgments
 

--- a/proposals/0005-note-blocks.md
+++ b/proposals/0005-note-blocks.md
@@ -39,7 +39,7 @@ a Markdown-inspired syntax for clarity and simplicity.
 
 To add a note, authors will simply use a > symbol at the beginning of a paragraph:
 
-```
+```cook
 > This dish is even better the next day, after the flavors have melded overnight.
 ```
 
@@ -55,13 +55,46 @@ The design introduces a straightforward syntax addition to the Cooklang grammar.
 In a recipe file, any line beginning with `>` will be recognized as a note and
 rendered as such in applications that support the new syntax.
 
+Also we should support starting every line with `>`, just like in markdown. For example:
+
+```cook
+> This is a long note
+> and the user writes the `>` at the beginning of
+> every line. All the `>` markup is stripped from the
+> note "output".
+```
+
+This is optional, so it's the same as:
+
+```cook
+> This is a long note
+and the user writes the `>` at the beginning of
+every line. All the `>` markup is stripped from the
+note "output".
+```
+
+It's the same as markdown blockquotes but one paragraph per note block.
+In Markdown this would be two paragraphs in the same blockquoute but
+in Cooklang it's all the same paragraph, newline is removed.
+
+```md
+> In markdown
+>
+> Two paragraphs
+```
+
+Unlike Markdown, Cooklang shouldn't support nesting notes inside each other.
+
 ### EBNF update
 
 ```
 recipe = { metadata | step | note }- ;
 
-note = ">", { text item }-, new line character ;
+blank line = { white space }, new line character ;
+note marker = ">" ;
+note = { note marker, { text item }, blank line }-, blank line ;
 ```
+Symbols and definitions are [here](https://github.com/cooklang/spec/blob/main/EBNF.md).
 
 ## Effect on applications which use Cooklang
 

--- a/proposals/0005-note-blocks.md
+++ b/proposals/0005-note-blocks.md
@@ -1,0 +1,73 @@
+# Note blocks
+
+* Proposal: [0005-note-blocks](0005-note-blocks.md)
+* Authors: [Alexey Dubovskoy](https://github.com/dubadub)
+* Status: **Awaiting review**
+
+## Introduction
+
+The proposal aims to add a new block type to the Cooklang language: note.
+
+This new block type will allow recipe authors to add arbitrary notes to the recipe,
+which will be displayed in the app as notes.
+
+Why we need this?
+
+Discussion thread: ["Additional notes" section which isn't a step, but extra information about a recipe](https://github.com/cooklang/spec/discussions/81) and [Description, notes, and metadata...](https://github.com/cooklang/spec/discussions/46).
+
+## Motivation
+
+Describe the problems that this proposal seeks to address. If the
+problem is that some common pattern is currently hard to express, show
+how one can currently get a similar effect and describe its
+drawbacks. If it's completely new functionality that cannot be
+emulated, motivate why this new functionality would help Cooklang community
+use Cooklang better.
+
+## Proposed solution
+
+Describe your solution to the problem. Provide examples and describe
+how they work. Show how your solution is better than current
+workarounds (if any).
+
+## Detailed design
+
+Describe the design of the solution in detail. If it involves new
+syntax in the language, show the additions and changes to the Cooklang
+grammar. If it's a new API, show the full API and its documentation
+comments detailing what it does. The detail in this section should be
+sufficient for someone who is *not* one of the authors to be able to
+reasonably implement the feature.
+
+## Effect on applications which use Cooklang
+
+Changes in Cooklang syntax often require supplementary UI changes in
+apps which use it (otherwise why these changes if nothing will
+use them). Describe in details what changes should be implemented.
+The detail in this section should be sufficient for someone
+who is *not* one of the authors to be able to reasonably implement
+the feature.
+
+### CookCLI (terminal and web-server)
+
+Does the proposal change the output of
+[CookCLI](https://github.com/cooklang/CookCLI)? Does it require adding
+a new sub-command to fully use this feature?
+
+### Mobile applications
+
+Does the proposal require changes in mobile application UI? Describe
+what screens should be changed and how. Give as much details as
+possible.
+
+## Alternatives considered
+
+Describe alternative approaches to addressing the same problem, and
+why you chose this approach instead.
+
+## Acknowledgments
+
+If significant changes or improvements suggested by members of the
+community were incorporated into the proposal as it developed, take a
+moment here to thank them for their contributions. Cooklang evolution is a
+collaborative process, and everyone's input should receive recognition!

--- a/proposals/0005-note-blocks.md
+++ b/proposals/0005-note-blocks.md
@@ -93,7 +93,4 @@ and accessible without interference.
 
 ## Acknowledgments
 
-If significant changes or improvements suggested by members of the
-community were incorporated into the proposal as it developed, take a
-moment here to thank them for their contributions. Cooklang evolution is a
-collaborative process, and everyone's input should receive recognition!
+The feature has been implemented by [@Zheoni](https://github.com/Zheoni) as parser extension.


### PR DESCRIPTION
[Rendered](https://github.com/cooklang/spec/blob/proposal/0005-note-blocks/proposals/0005-note-blocks.md)

This PR introduces a new "note" block type to the Cooklang language, allowing recipe authors to add contextual notes or personal anecdotes to recipes. Notes are designed to appear in the recipe details but will be hidden in cooking mode, keeping the main instructions uncluttered.

### Key Changes:
- **Syntax Addition**: Notes can now be created by prefixing a paragraph with a `>` symbol. 
  ```cooklang
  > This recipe is a family favorite that tastes even better the next day.
  ```
- **Grammar Update**: Added `note` rule to the EBNF for Cooklang to support the new syntax.
- **UI Impact**: Apps displaying Cooklang recipes will need minor UI adjustments to show notes in the recipe details while hiding them in cooking mode.
  
### Rationale:
Notes allow recipe creators to add meaningful, non-instructional content to recipes, enhancing the reader’s experience without disrupting the cooking process. 

### Related Discussions:
- ["Additional notes" section which isn't a step, but extra information about a recipe](https://github.com/cooklang/spec/discussions/81)
- [Description, notes, and metadata...](https://github.com/cooklang/spec/discussions/46)

This addition brings storytelling and contextual flexibility to Cooklang, making it easier for authors to share background and tips alongside recipes.